### PR TITLE
Update tests to use :embedded hornetq instance instead of :vm

### DIFF
--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -7,24 +7,31 @@
 
 (def id (java.util.UUID/randomUUID))
 
+(def config (read-string (slurp (clojure.java.io/resource "test-config.edn"))))
+
 (def scheduler :onyx.job-scheduler/round-robin)
 
 (def env-config
-  {:hornetq/mode :vm
+  {:hornetq/mode :standalone
    :hornetq/server? true
-   :hornetq.server/type :vm
-   :zookeeper/address "127.0.0.1:2185"
+   :hornetq.server/type :embedded
+   :hornetq.embedded/config ["hornetq/non-clustered-1.xml"]
+   :hornetq.standalone/host (:host (:non-clustered (:hornetq config)))
+   :hornetq.standalone/port (:port (:non-clustered (:hornetq config)))
+   :zookeeper/address (:address (:zookeeper config))
    :zookeeper/server? true
-   :zookeeper.server/port 2185
+   :zookeeper.server/port (:spawn-port (:zookeeper config))
    :onyx/id id
    :onyx.peer/job-scheduler scheduler})
 
 (def peer-config
-  {:hornetq/mode :vm
-   :zookeeper/address "127.0.0.1:2185"
+  {:hornetq/mode :standalone
+   :hornetq.standalone/host (:host (:non-clustered (:hornetq config)))
+   :hornetq.standalone/port (:port (:non-clustered (:hornetq config)))
+   :zookeeper/address (:address (:zookeeper config))
    :onyx/id id
-   :onyx.peer/inbox-capacity 100
-   :onyx.peer/outbox-capacity 100
+   :onyx.peer/inbox-capacity (:inbox-capacity (:peer config))
+   :onyx.peer/outbox-capacity (:outbox-capacity (:peer config))
    :onyx.peer/job-scheduler scheduler})
 
 (def env (onyx.api/start-env env-config))
@@ -52,11 +59,8 @@
 
 (def tx-queue (d/tx-report-queue datomic-conn))
 
-(def hornetq-host "localhost")
-
-(def hornetq-port 5465)
-
-(def hq-config {"host" hornetq-host "port" hornetq-port})
+(def hq-config {"host" (:host (:non-clustered (:hornetq config)))
+                "port" (:port (:non-clustered (:hornetq config)))})
 
 (def in-queue (str (java.util.UUID/randomUUID)))
 

--- a/test/onyx/plugin/output_test.clj
+++ b/test/onyx/plugin/output_test.clj
@@ -84,8 +84,8 @@
     :onyx/medium :hornetq
     :onyx/consumption :concurrent
     :hornetq/queue-name in-queue
-    :hornetq/host hornetq-host
-    :hornetq/port hornetq-port
+    :hornetq/host (:host (:non-clustered (:hornetq config)))
+    :hornetq/port (:port (:non-clustered (:hornetq config)))
     :onyx/batch-size 2}
 
    {:onyx/name :identity


### PR DESCRIPTION
I couldn't get this test to pass without changing to :embedded since it refused to connect to the :vm instance.

This test is now similar to the standalone_test inside the main onyx repo. It also relies on the config and xml resources being available from the onyx dependency.
