### PR TITLE
New datomic txn log support for memory dbs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                              :username :env
                              :password :env
                              :sign-releases false}}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  ^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
                  [org.onyxplatform/onyx "0.9.10"]
                  [aero "0.2.0"]]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
   :test-selectors {:default (complement :ci)
                    :ci :ci
                    :all (constantly true)}
-  :profiles {:dev {:dependencies [[com.datomic/datomic-free "0.9.5153"]]
+  :profiles {:dev {:dependencies [[com.datomic/datomic-free "0.9.5394"]]
                    :plugins [[lein-set-version "0.4.1"]
                              [lein-update-dependency "0.1.2"]
                              [lein-pprint "1.1.1"]]

--- a/src/onyx/plugin/datomic.clj
+++ b/src/onyx/plugin/datomic.clj
@@ -277,8 +277,6 @@
 
 (defn inject-read-log-resources
   [{:keys [onyx.core/task-map onyx.core/log onyx.core/task-id onyx.core/job-id onyx.core/pipeline] :as event} lifecycle]
-  (when (re-matches #"datomic:mem://.*" (:datomic/uri task-map))
-    (throw (ex-info "Read datoms cannot support in mem datomic instances, as these do not have a transaction log." task-map)))
 
   (when-not (or (= 1 (:onyx/max-peers task-map))
                 (= 1 (:onyx/n-peers task-map)))


### PR DESCRIPTION
Datomic now provides access to the Datomic Log API for memory databases. See [this announcement](http://blog.datomic.com/2016/08/log-api-for-memory-databases.html).
