### PR TITLE
Allow read-log to complete when there's no more txes

### DIFF
--- a/test/onyx/plugin/input_log_test.clj
+++ b/test/onyx/plugin/input_log_test.clj
@@ -91,7 +91,7 @@
     (try
       (with-test-env [test-env [4 env-config peer-config]]
         (testing "That we can read the initial transaction log"
-          (let [job (build-job db-uri 1002 10 1000)
+          (let [job (build-job db-uri 1001 10 1000)
                 {:keys [persist]} (get-core-async-channels job)
                 _ (mapv (partial ensure-datomic! db-uri) [schema people])
                 job-id (:job-id (onyx.api/submit-job peer-config job))]


### PR DESCRIPTION
This PR addresses #26. The issue I was having was that the job would never complete when there was an `end-tx`. This happened because `end-tx` was never checked before trying to load more transactions, and it would get stuck in a loop.

My use case that discovered this problem is an integration test where I want to read the last few transactions from the log. In a streaming situation, I don't think this would be an issue because it would just load more transactions and eventually complete.

I tested this using my integration test topology, and I'd be happy to include a proper test. However, I want to see if this makes sense before I do that.

Thanks!