### PR TITLE
Restartable errors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-datomic "0.9.15.1"
+(defproject org.onyxplatform/onyx-datomic "0.9.12.2-SNAPSHOT"
   :description "Onyx plugin for Datomic"
   :url "https://github.com/onyx-platform/onyx-datomic"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
We have an application still running on 0.9.x and our transactor occasionally fails over.  As is, this kills the job if we are in the middle of a tx.  I forked the [existing PR](https://github.com/onyx-platform/onyx-datomic/pull/24) that handles a similar situation, however it would not handle the exception thrown in the case of a transactor failing over.  In addition, datomic allows you to specify a transaction timeout via a property, i.e. `-Ddatomic.txTimeoutMsec=15000`, which throws an exception we can catch and handle in the plugin, but doesn't hard code the value in the plugin itself.  

We have started moving our existing jobs to 0.14 and I would like to do something similar in that version of the plugin, as well. 