### PR TITLE
Corrects errors in 0.9.15.2 tasks restarting on tx timeouts/unavailable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-datomic "0.9.15.2"
+(defproject org.onyxplatform/onyx-datomic "0.9.15.3-SNAPSHOT"
   :description "Onyx plugin for Datomic"
   :url "https://github.com/onyx-platform/onyx-datomic"
   :license {:name "Eclipse Public License"

--- a/src/onyx/plugin/datomic.clj
+++ b/src/onyx/plugin/datomic.clj
@@ -477,7 +477,6 @@
     (deref pending-tx)
     (catch Exception ex
       (let [cause (get-exception-cause ex)]
-        (println cause)
         (if (restartable-exceptions cause) 
           ::restartable-ex
           (throw (ex-info "Unrecoverable transaction exception. Not Rebooting task."

--- a/src/onyx/plugin/datomic.clj
+++ b/src/onyx/plugin/datomic.clj
@@ -460,8 +460,7 @@
   (when (throwable? ex)
     (if-let [db-error (:db/error (ex-data ex))]
       db-error
-      (let [cause (.getCause ex)
-            cause-throwable? (throwable? cause)]
+      (let [cause (.getCause ex)]
         (when (throwable? cause)
           (recur cause))))))
 
@@ -526,7 +525,7 @@
                               (d/transact conn (:tx (:message tx)))))
                        (doall)
                        (map try-deref)
-                       (doall))]
+                       (doall))] 
       (when (some #(= ::restartable-ex %) written)
         (throw (ex-info "Timed out transacting message to datomic. Rebooting task" 
                         {:restartable? true

--- a/test/onyx/plugin/test_datomic.clj
+++ b/test/onyx/plugin/test_datomic.clj
@@ -64,6 +64,10 @@
      (d/connect db-uri)
      data)))
 
+(defn random-db-uri
+  []
+  (str "datomic:mem://" (java.util.UUID/randomUUID)))
+
 (defn with-db-conn
   [db-uri data f]
   (let [db (ensure-datomic! db-uri data)
@@ -111,7 +115,7 @@
   (mock-msg {:tx [[:db/add (d/tempid :com.mdrogalis/people) :name "Mike"]]}))
 
 (deftest test-write-datoms
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -123,7 +127,7 @@
           (is (not-empty (:tx-data (:datomic/written output)))))))))
 
 (deftest test-write-datoms-tx-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -139,7 +143,7 @@
             (is (true? (:datomic-plugin? output)))))))))
 
 (deftest test-write-datoms-tx-not-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -157,7 +161,7 @@
                                                      write-datoms-test-event)))))))))
 
 (deftest test-write-bulk-datoms
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -169,7 +173,7 @@
           (is (not-empty (:tx-data (first (:datomic/written output))))))))))
 
 (deftest test-write-bulk-datoms-tx-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -185,7 +189,7 @@
             (is (true? (:datomic-plugin? output)))))))))
 
 (deftest test-write-datoms-not-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -203,7 +207,7 @@
                                                      write-bulk-datoms-event)))))))))
 
 (deftest test-write-bulk-datoms-async
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -215,7 +219,7 @@
           (is (not-empty (:tx-data (first (:datomic/written output))))))))))
 
 (deftest test-write-bulk-datoms-async-tx-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema
@@ -231,7 +235,7 @@
             (is (true? (:datomic-plugin? output)))))))))
 
 (deftest test-write-bulk-datoms-not-restartable
-  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+  (let [db-uri (random-db-uri)]
     (with-db-conn
       db-uri
       schema

--- a/test/onyx/plugin/test_datomic.clj
+++ b/test/onyx/plugin/test_datomic.clj
@@ -1,0 +1,38 @@
+(ns onyx.plugin.test-datomic
+  (:require [onyx.plugin.datomic :as sut]
+            [clojure.test :refer :all]))
+
+(def test-ex1
+  (ex-info "Transaction timeout"
+           {:db/error :db.error/transaction-timeout}))
+
+(def test-ex2
+  (Exception. "Transactor Timeout"
+              (ex-info "Transactor Unavailable"
+                       {:db/error :db.error/transactor-unavailable})))
+
+(def test-ex-other1
+  (ex-info "Other Exception"
+           {:db/error :db.error/unique-conflict}))
+
+(def test-ex-other2
+  (Exception. "Other Exception 2" test-ex-other1))
+
+(deftest test-get-exception-cause
+  (is (= :db.error/transaction-timeout (sut/get-exception-cause test-ex1)))
+  (is (= :db.error/transactor-unavailable (sut/get-exception-cause test-ex2))))
+
+(deftest test-try-deref
+  (is (= ::sut/restartable-ex (sut/try-deref (future (throw test-ex1)))))
+  (is (= ::sut/restartable-ex (sut/try-deref (future (throw test-ex2)))))
+  (is (thrown-with-msg? Exception
+                        #"Unrecoverable transaction"
+                        (sut/try-deref (future (throw test-ex-other1)))))
+  (is (thrown-with-msg? Exception
+                        #"Unrecoverable transaction"
+                        (sut/try-deref (future (throw test-ex-other2))))))
+
+
+
+
+

--- a/test/onyx/plugin/test_datomic.clj
+++ b/test/onyx/plugin/test_datomic.clj
@@ -1,6 +1,10 @@
 (ns onyx.plugin.test-datomic
   (:require [onyx.plugin.datomic :as sut]
-            [clojure.test :refer :all]))
+            [onyx.peer.pipeline-extensions :as p-ext]
+            [clojure.test :refer :all]
+            [datomic.api :as d]))
+
+;; Test exception handling
 
 (def test-ex1
   (ex-info "Transaction timeout"
@@ -11,6 +15,21 @@
               (ex-info "Transactor Unavailable"
                        {:db/error :db.error/transactor-unavailable})))
 
+(def nested-db-error
+  (Exception. "Top Level"
+              (Exception. "One Down"
+                          (Exception. "And another"
+                                      (ex-info "Transactor Unavailable"
+                                               {:db/error
+                                                :db.error/transactor-unavailable})))))
+
+(def nested-other-error
+  (Exception. "Top Level"
+              (Exception. "One Down"
+                          (Exception. "And another"
+                                      (ex-info "Not a DB error"
+                                               {:not.db/error :something-else})))))
+
 (def test-ex-other1
   (ex-info "Other Exception"
            {:db/error :db.error/unique-conflict}))
@@ -18,9 +37,11 @@
 (def test-ex-other2
   (Exception. "Other Exception 2" test-ex-other1))
 
-(deftest test-get-exception-cause
-  (is (= :db.error/transaction-timeout (sut/get-exception-cause test-ex1)))
-  (is (= :db.error/transactor-unavailable (sut/get-exception-cause test-ex2))))
+(deftest test-db-error
+  (is (= :db.error/transaction-timeout (sut/db-error test-ex1)))
+  (is (= :db.error/transactor-unavailable (sut/db-error test-ex2)))
+  (is (= :db.error/transactor-unavailable (sut/db-error nested-db-error)))
+  (is (nil? (sut/db-error nested-other-error))))
 
 (deftest test-try-deref
   (is (= ::sut/restartable-ex (sut/try-deref (future (throw test-ex1)))))
@@ -34,5 +55,196 @@
 
 
 
+;; Test plugin write-batch fns
 
+(defn ensure-datomic!
+  ([db-uri data]
+   (d/create-database db-uri)
+   @(d/transact
+     (d/connect db-uri)
+     data)))
+
+(defn with-db-conn
+  [db-uri data f]
+  (let [db (ensure-datomic! db-uri data)
+        db-conn (d/connect db-uri)]
+    (try (f db-conn)
+         (finally (d/delete-database db-uri)))))
+
+(def schema
+  [{:db/id #db/id [:db.part/db]
+    :db/ident :com.mdrogalis/people
+    :db.install/_partition :db.part/db}
+
+   {:db/id #db/id [:db.part/db]
+    :db/ident :name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}])
+
+(defn mock-msg
+  [message]
+  {:onyx.core/results
+   {:tree
+    [{:root
+      {:message message,
+       :id #uuid "04937498-9738-fadb-7f77-d8b43813ba8f",
+       :offset nil,
+       :acker-id #uuid "be180c11-603e-42a4-8e96-cef4a85cd83b",
+       :completion-id #uuid "be180c11-603e-42a4-8e96-cef4a85cd83b",
+       :ack-val -9060905885493246379,
+       :hash-group nil,
+       :route nil},
+      :leaves
+      [{:message message,
+        :id #uuid "04937498-9738-fadb-7f77-d8b43813ba8f",
+        :offset nil,
+        :acker-id #uuid "be180c11-603e-42a4-8e96-cef4a85cd83b",
+        :completion-id #uuid "be180c11-603e-42a4-8e96-cef4a85cd83b",
+        :ack-val nil,
+        :hash-group nil,
+        :route nil}]}]}})
+
+(def write-datoms-test-event (mock-msg {:name "mike"}))
+
+(def write-bulk-datoms-event
+  (mock-msg {:tx [[:db/add (d/tempid :com.mdrogalis/people) :name "Mike"]]}))
+
+(deftest test-write-datoms
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (let [w-datoms (sut/map->DatomicWriteDatoms {:conn conn
+                                                     :partition :com.mdrogalis/people})
+              output (p-ext/write-batch w-datoms write-datoms-test-event)]
+          (is (true? (:datomic/written? output)))
+          (is (not-empty (:tx-data (:datomic/written output)))))))))
+
+(deftest test-write-datoms-tx-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact (fn [& _] (future (throw test-ex1)))]
+          (let [w-datoms (sut/map->DatomicWriteDatoms {:conn conn
+                                                       :partition :com.mdrogalis/people})
+                ex (try
+                     (p-ext/write-batch w-datoms write-datoms-test-event)
+                     (catch Exception ex ex))
+                output (ex-data ex)]
+            (is (true? (:restartable? output)))
+            (is (true? (:datomic-plugin? output)))))))))
+
+(deftest test-write-datoms-tx-not-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact
+                      (fn [& _]
+                        (future (throw test-ex-other1)))]
+          (let [w-datoms (sut/map->DatomicWriteDatoms
+                          {:conn conn
+                           :partition :com.mdrogalis/people})]
+           
+            (is (thrown-with-msg? Exception
+                                  #"Unrecoverable transaction"
+                                  (p-ext/write-batch w-datoms
+                                                     write-datoms-test-event)))))))))
+
+(deftest test-write-bulk-datoms
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (let [w-datoms (sut/map->DatomicWriteBulkDatoms {:conn conn
+                                                     :partition :com.mdrogalis/people})
+              output (p-ext/write-batch w-datoms write-bulk-datoms-event)]
+          (is (true? (:datomic/written? output)))
+          (is (not-empty (:tx-data (first (:datomic/written output))))))))))
+
+(deftest test-write-bulk-datoms-tx-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact (fn [& _] (future (throw test-ex1)))]
+          (let [w-datoms (sut/map->DatomicWriteBulkDatoms {:conn conn
+                                                           :partition :com.mdrogalis/people})
+                ex (try
+                     (p-ext/write-batch w-datoms write-bulk-datoms-event)
+                     (catch Exception ex ex))
+                output (ex-data ex)]
+            (is (true? (:restartable? output)))
+            (is (true? (:datomic-plugin? output)))))))))
+
+(deftest test-write-datoms-not-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact
+                      (fn [& _]
+                        (future (throw test-ex-other1)))]
+          (let [w-datoms (sut/map->DatomicWriteBulkDatoms
+                          {:conn conn
+                           :partition :com.mdrogalis/people})]
+           
+            (is (thrown-with-msg? Exception
+                                  #"Unrecoverable transaction"
+                                  (p-ext/write-batch w-datoms
+                                                     write-bulk-datoms-event)))))))))
+
+(deftest test-write-bulk-datoms-async
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (let [w-datoms (sut/map->DatomicWriteBulkDatomsAsync {:conn conn
+                                                              :partition :com.mdrogalis/people})
+              output (p-ext/write-batch w-datoms write-bulk-datoms-event)]
+          (is (true? (:datomic/written? output)))
+          (is (not-empty (:tx-data (first (:datomic/written output))))))))))
+
+(deftest test-write-bulk-datoms-async-tx-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact-async (fn [& _] (future (throw test-ex1)))]
+          (let [w-datoms (sut/map->DatomicWriteBulkDatomsAsync {:conn conn
+                                                                :partition :com.mdrogalis/people})
+                ex (try
+                     (p-ext/write-batch w-datoms write-bulk-datoms-event)
+                     (catch Exception ex ex))
+                output (ex-data ex)]
+            (is (true? (:restartable? output)))
+            (is (true? (:datomic-plugin? output)))))))))
+
+(deftest test-write-bulk-datoms-not-restartable
+  (let [db-uri (str "datomic:mem://" (java.util.UUID/randomUUID))]
+    (with-db-conn
+      db-uri
+      schema
+      (fn [conn]
+        (with-redefs [datomic.api/transact-async
+                      (fn [& _]
+                        (future (throw test-ex-other1)))]
+          (let [w-datoms (sut/map->DatomicWriteBulkDatomsAsync
+                          {:conn conn
+                           :partition :com.mdrogalis/people})]
+           
+            (is (thrown-with-msg? Exception
+                                  #"Unrecoverable transaction"
+                                  (p-ext/write-batch w-datoms
+                                                     write-bulk-datoms-event)))))))))
 


### PR DESCRIPTION
@lbradstreet it looks like I missed a few things in the 0.9.15.2 branch that prevented the tasks from being restarted.  I honestly wasn't expecting for it to be merged straight away!!   


in this branch: 

* fix the issue with detecting when the exceptions we are restarting on are thrown in the bulk datoms output tasks.
* made detecting the exceptions in the first place more robust
* added tests for the above
* added tests around the `write-batch` implementation for each output and make sure the restart code is working properly, given the appropriate exceptions and behaves as it did before, otherwise. 


Sorry for taking up your time with an unsupported branch, but if you could cut a release, it would be helpful to us as we transition to 0.14.x. 

Speaking of, for 0.14.x, I am going to add something to the information model to make this restartable behavior optional, I think.  I can imagine some folks might not want to reboot the task on those conditions.  I have started working on that branch already and, hopefully, will have that to you soon.  