### PR TITLE
Datomic API NS discovery in onyx.datomic.api fixed for modern peer

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
+#### 0.14.5.1
+* Updated `onyx.datomic.api` NS discovery to pick correct Datomic driver against modern datomic-pro releases
+
 #### 0.10.0.1
 * Fix bug in read-log recovery, where start tx would jump forward by 1 on recovery.
 
@@ -30,4 +33,3 @@
 #### 0.7.0.1
 * New index-range catalog type
 * read-datoms can now supply components to datoms via :datomic/datoms-components
-

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-datomic "0.14.5.0"
+(defproject org.onyxplatform/onyx-datomic "0.14.5.1"
   :description "Onyx plugin for Datomic"
   :url "https://github.com/onyx-platform/onyx-datomic"
   :license {:name "Eclipse Public License"
@@ -18,7 +18,7 @@
                    :ci :ci
                    :cloud :cloud
                    :all (constantly true)}
-  
+
   :profiles {:dev {:dependencies [[aero "0.2.0"]
                                   [com.fzakaria/slf4j-timbre "0.3.8"]
                                   [org.slf4j/slf4j-api "1.7.14"]

--- a/src/onyx/datomic/api.clj
+++ b/src/onyx/datomic/api.clj
@@ -8,11 +8,11 @@
      (catch FileNotFoundException _ (require '[datomic.api :as d])))
 
 (defn- _datomic-lib-type []
-  (if (find-ns 'datomic.client.api)
+  (if (find-ns 'datomic.api)
+    :peer
     (try (require '[datomic.client.impl.cloud])
          :cloud
-         (catch FileNotFoundException _ :client))
-    :peer))
+         (catch FileNotFoundException _ :client))))
 
 (def datomic-lib-type (memoize _datomic-lib-type))
 


### PR DESCRIPTION
Was broken b/c Datomic Peer started including ns datomic.client.api.

For posterity, copying my full writeup from [Clojurians #onyx](https://clojurians.slack.com/messages/C051WKSP3) below.

================================================

In the latest version of `[com.datomic/datomic-pro "0.9.5951"]`, the namespace `com.datomic:client-api:jar:0.8.35:compile` is included.
I'd like to use the Peer API, but this namespace inclusion is tripping up the automatic `:peer` vs `:cloud` vs `:client` discovery mechanism in `onyx.datomic.api` --
```
(defn- _datomic-lib-type []
  (if (find-ns 'datomic.client.api)
    (try (require '[datomic.client.impl.cloud])
         :cloud
         (catch FileNotFoundException _ :client))
    :peer))

(def datomic-lib-type (memoize _datomic-lib-type))
```
The oldest release I'm allowed to go back to in my.datomic.com is `"0.9.5783"`, which still has `com.datomic:client-api:jar:0.8.7`.

I found a way around this:

```
;; in project.clj :dependencies
[com.datomic/datomic-pro "0.9.5951" :exclusions [[com.datomic/client-api]]]
```

As far as a permanent solution: the client-api doesn't include namespace `datomic.api`, so might fix it to check for that namespace first. The last version of the client API I could find to test with is `[com.datomic/client-pro "0.8.28"]`, which definitely doesn't have that namespace.

I did confirm that client-cloud version `[com.datomic/client-cloud "0.8.78"]` still uses namespace `[datomic.client.impl.cloud]`, so the auto-detection for that should still continue working.